### PR TITLE
[FIX] correcting removal of the automation code

### DIFF
--- a/account_mtd/models/mtd_hmrc_configuration.py
+++ b/account_mtd/models/mtd_hmrc_configuration.py
@@ -21,28 +21,3 @@ class MtdHmrcConfiguration(models.Model):
     access_token = fields.Char()
     refresh_token = fields.Char()
     state = fields.Char()
-    redonly_on_live = fields.Boolean(default=False)
-
-    @api.onchange('environment')
-    def onchange_environment(self):
-
-        if self.environment == 'live':
-            # Note If there are any change to these fields please copy the changes to the create function as well
-            self.name = 'HMRC Live Environment'
-            self.server_token = '5b9635be5d53d5d87bdcb051ee90e760'
-            self.client_id = '4wB_PpdQAn81wCE0usci6_xSzYIa'
-            self.client_secret = '44c3ae5a-cbbf-4fa5-a5fc-04c96a10d719'
-            self.hmrc_url = 'https://api.service.hmrc.gov.uk/'
-            self.redonly_on_live = True
-
-            self.search([('environment', '=', 'live')]).write({
-                'name':'HMRC Live Environment'
-            })
-
-        else:
-            self.name = ''
-            self.server_token = ''
-            self.client_id = ''
-            self.client_secret = ''
-            self.hmrc_url = ''
-            self.redonly_on_live = False


### PR DESCRIPTION
Originally there was a point when we added the auto configuration for HMRC set up. The decision was made to remove it. Looks like as if it was not removed from V10, V11 and V12